### PR TITLE
Add connectivity check for dungeon

### DIFF
--- a/Assets/Scripts/DungeonGenerator.cs
+++ b/Assets/Scripts/DungeonGenerator.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
-using NUnit.Framework;
 using Unity.AI.Navigation;
-using Unity.VisualScripting;
 using UnityEngine;
 
 public class DungeonGenerator : MonoBehaviour
@@ -47,6 +45,7 @@ public class DungeonGenerator : MonoBehaviour
         CreateOuterWalls(initialBounds);
         surface.BuildNavMesh();
         Instantiate(heroPrefab, new Vector3(5, 0.5f, 5), Quaternion.identity);
+        Debug.Log($"Dungeon fully connected: {IsDungeonFullyConnected()}");
     }
 
     void Update()
@@ -429,6 +428,13 @@ public class DungeonGenerator : MonoBehaviour
     public bool IsDungeonFullyConnected()
     {
         return IsGraphConnected(allRooms);
+    }
+
+    public bool TestConnectivity()
+    {
+        bool connected = IsDungeonFullyConnected();
+        Debug.Log($"Dungeon fully connected: {connected}");
+        return connected;
     }
 
     public static bool IsGraphConnected(List<Room> rooms)

--- a/Assets/Scripts/DungeonGenerator.cs
+++ b/Assets/Scripts/DungeonGenerator.cs
@@ -425,4 +425,35 @@ public class DungeonGenerator : MonoBehaviour
             AlgorithmsUtils.DebugRectInt(doorRect, Color.cyan);
         }
     }
+
+    public bool IsDungeonFullyConnected()
+    {
+        return IsGraphConnected(allRooms);
+    }
+
+    public static bool IsGraphConnected(List<Room> rooms)
+    {
+        if (rooms == null || rooms.Count == 0)
+            return true;
+
+        var visited = new HashSet<Room>();
+        var queue = new Queue<Room>();
+
+        visited.Add(rooms[0]);
+        queue.Enqueue(rooms[0]);
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            foreach (var neighbor in current.ConnectedRooms)
+            {
+                if (visited.Add(neighbor))
+                {
+                    queue.Enqueue(neighbor);
+                }
+            }
+        }
+
+        return visited.Count == rooms.Count;
+    }
 }

--- a/Assets/Tests/DungeonConnectivityTests.cs
+++ b/Assets/Tests/DungeonConnectivityTests.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+public class DungeonConnectivityTests
+{
+    [Test]
+    public void GraphConnected_BFS_ChecksConnectivity()
+    {
+        var roomA = new Room();
+        var roomB = new Room();
+        var roomC = new Room();
+
+        roomA.ConnectedRooms.Add(roomB);
+        roomB.ConnectedRooms.Add(roomA);
+        roomB.ConnectedRooms.Add(roomC);
+        roomC.ConnectedRooms.Add(roomB);
+
+        var rooms = new List<Room> { roomA, roomB, roomC };
+        Assert.IsTrue(DungeonGenerator.IsGraphConnected(rooms));
+    }
+
+    [Test]
+    public void GraphDisconnected_BFS_FindsDisconnection()
+    {
+        var roomA = new Room();
+        var roomB = new Room();
+        var roomC = new Room();
+
+        roomA.ConnectedRooms.Add(roomB);
+        roomB.ConnectedRooms.Add(roomA);
+        // roomC is isolated
+
+        var rooms = new List<Room> { roomA, roomB, roomC };
+        Assert.IsFalse(DungeonGenerator.IsGraphConnected(rooms));
+    }
+}


### PR DESCRIPTION
## Summary
- implement BFS connectivity check in `DungeonGenerator`
- add unit tests verifying connected and disconnected graphs

## Testing
- `unity-editor -runTests -projectPath . -testResults results.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3a653ec08320a51bf488e4bd0cd6